### PR TITLE
Use get-port for knockingPort in test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,12 +26,7 @@ jobs:
     docker:
       - image: circleci/node:8
     <<: *node_steps
-  
-  node_6:
-    docker:
-      - image: circleci/node:6
-    <<: *node_steps
-  
+
   docker_test:
     machine: true
     steps:
@@ -83,16 +78,11 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - node_6:
-          filters:
-            tags:
-              only: /.*/
       - docker_test
       - npm_publish:
           requires:
             - node_10
             - node_8
-            - node_6
           filters:
             tags:
               only: /.*/

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ sudo: false
 node_js:
   - "10"
   - "8"
-  - "6"
 install:
   - npm install
 script:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1398,6 +1398,15 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
+    "get-port": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.0.0.tgz",
+      "integrity": "sha512-imzMU0FjsZqNa6BqOjbbW6w5BivHIuQKopjpPqcnx0AVHJQKCxK1O+Ab3OrVXhrekqfVMjwA9ZYu062R+KcIsQ==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.3.0"
+      }
+    },
     "get-stream": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
@@ -3278,6 +3287,12 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "optional": true
+    },
+    "type-fest": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.0.tgz",
+      "integrity": "sha512-fg3sfdDdJDtdHLUpeGsf/fLyG1aapk6zgFiYG5+MDUPybGrJemH4SLk5tP7hGRe8ntxjg0q5LYW53b6YpJIQ9Q==",
+      "dev": true
     },
     "type-is": {
       "version": "1.6.16",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@types/ws": "^6.0.0",
     "@types/yargs": "^12.0.0",
     "express": "^4.16.3",
+    "get-port": "^5.0.0",
     "mocha": "^6.0.1",
     "power-assert": "^1.5.0",
     "promise-http-server": "^0.1.0",

--- a/test/knocking-server.test.ts
+++ b/test/knocking-server.test.ts
@@ -7,6 +7,7 @@ import * as WebSocket from 'ws';
 import * as testUtil from './test-util';
 import * as jsonTemplates from "json-templates";
 import * as timekeeper from "timekeeper";
+import * as getPort from "get-port";
 import {PromiseHttpServer} from "promise-http-server";
 
 import * as knockingServer from '../src/knocking-server';
@@ -121,7 +122,7 @@ describe("knockingServer", ()=>{
 
 
     it("should be closed by default", async ()=>{
-      const knockingPort: number = 6677;
+      const knockingPort: number = await getPort();
       const knockingUrl: string = `http://localhost:${knockingPort}`;
       const openKnockingSeq: string[] = ["/82", "/delta", "/echo"];
       const closeKnockingSeq: string[] = ["/alpha", "/one", "/one", "/three"];
@@ -149,7 +150,7 @@ describe("knockingServer", ()=>{
 
 
     it("should open by open-knocking sequence", async ()=>{
-      const knockingPort: number = 6677;
+      const knockingPort: number = await getPort();
       const knockingUrl: string = `http://localhost:${knockingPort}`;
       const openKnockingSeq: string[] = ["/82", "/delta", "/echo"];
       const closeKnockingSeq: string[] = ["/alpha", "/one", "/one", "/three"];
@@ -194,7 +195,7 @@ describe("knockingServer", ()=>{
     });
 
     it("should open by open-knocking sequence with other requests", async ()=>{
-      const knockingPort: number = 6677;
+      const knockingPort: number = await getPort();
       const knockingUrl: string = `http://localhost:${knockingPort}`;
       const openKnockingSeq: string[] = ["/82", "/delta", "/echo"];
       const closeKnockingSeq: string[] = ["/alpha", "/one", "/one", "/three"];
@@ -237,7 +238,7 @@ describe("knockingServer", ()=>{
     });
 
     it("should close by close-knocking sequence", async ()=>{
-      const knockingPort: number = 6677;
+      const knockingPort: number = await getPort();
       const knockingUrl: string = `http://localhost:${knockingPort}`;
       const openKnockingSeq: string[] = ["/82", "/delta", "/echo"];
       const closeKnockingSeq: string[] = ["/alpha", "/one", "/one", "/three"];
@@ -296,7 +297,7 @@ describe("knockingServer", ()=>{
     });
 
     it("should close by close-knocking sequence with other requests", async ()=>{
-      const knockingPort: number = 6677;
+      const knockingPort: number = await getPort();
       const knockingUrl: string = `http://localhost:${knockingPort}`;
       const openKnockingSeq: string[] = ["/82", "/delta", "/echo"];
       const closeKnockingSeq: string[] = ["/alpha", "/one", "/one", "/three"];
@@ -349,7 +350,7 @@ describe("knockingServer", ()=>{
     });
 
     it("should close automatically by time", async ()=>{
-      const knockingPort: number = 6677;
+      const knockingPort: number = await getPort();
       const knockingUrl: string = `http://localhost:${knockingPort}`;
       const openKnockingSeq: string[] = ["/82", "/delta", "/echo"];
       const closeKnockingSeq: string[] = ["/alpha", "/one", "/one", "/three"];
@@ -396,7 +397,7 @@ describe("knockingServer", ()=>{
     });
 
     it("should cancel auto-close-by-time by manual close", async ()=>{
-      const knockingPort: number = 6677;
+      const knockingPort: number = await getPort();
       const knockingUrl: string = `http://localhost:${knockingPort}`;
       const openKnockingSeq: string[] = ["/82", "/delta", "/echo"];
       const closeKnockingSeq: string[] = ["/alpha", "/one", "/one", "/three"];
@@ -450,7 +451,7 @@ describe("knockingServer", ()=>{
     });
 
     it("should open under open-knocking max interval", async ()=>{
-      const knockingPort: number = 6677;
+      const knockingPort: number = await getPort();
       const knockingUrl: string = `http://localhost:${knockingPort}`;
       const openKnockingSeq: string[] = ["/82", "/delta", "/echo"];
       const closeKnockingSeq: string[] = ["/alpha", "/one", "/one", "/three"];
@@ -489,7 +490,7 @@ describe("knockingServer", ()=>{
     });
 
     it("should close over open-knocking max interval, and open in correct way", async ()=>{
-      const knockingPort: number = 6677;
+      const knockingPort: number = await getPort();
       const knockingUrl: string = `http://localhost:${knockingPort}`;
       const openKnockingSeq: string[] = ["/82", "/delta", "/echo"];
       const closeKnockingSeq: string[] = ["/alpha", "/one", "/one", "/three"];
@@ -537,7 +538,7 @@ describe("knockingServer", ()=>{
     });
 
     it("should connect restricted number of HTTP requests", async ()=>{
-      const knockingPort: number = 6677;
+      const knockingPort: number = await getPort();
       const knockingUrl: string = `http://localhost:${knockingPort}`;
       const openKnockingSeq: string[] = ["/82", "/delta", "/echo"];
       const closeKnockingSeq: string[] = ["/alpha", "/one", "/one", "/three"];
@@ -586,7 +587,7 @@ describe("knockingServer", ()=>{
     });
 
     it("should connect restricted number of on-upgrade", async ()=>{
-      const knockingPort: number = 6677;
+      const knockingPort: number = await getPort();
       const knockingUrl: string = `http://localhost:${knockingPort}`;
       const openKnockingSeq: string[] = ["/82", "/delta", "/echo"];
       const closeKnockingSeq: string[] = ["/alpha", "/one", "/one", "/three"];
@@ -649,7 +650,7 @@ describe("knockingServer", ()=>{
     });
 
     it("should return fake Nginx Internal Server Error", async ()=>{
-      const knockingPort: number = 6677;
+      const knockingPort: number = await getPort();
       const knockingUrl: string = `http://localhost:${knockingPort}`;
       const openKnockingSeq: string[] = ["/82", "/delta", "/echo"];
       const closeKnockingSeq: string[] = ["/alpha", "/one", "/one", "/three"];
@@ -759,7 +760,7 @@ describe("knockingServer", ()=>{
     });
 
     it("should return fake Nginx Internal Server Error with padding", async ()=>{
-      const knockingPort: number = 6677;
+      const knockingPort: number = await getPort();
       const knockingUrl: string = `http://localhost:${knockingPort}`;
       const openKnockingSeq: string[] = ["/82", "/delta", "/echo"];
       const closeKnockingSeq: string[] = ["/alpha", "/one", "/one", "/three"];
@@ -842,7 +843,7 @@ describe("knockingServer", ()=>{
     });
 
     it("should return empty response", async ()=>{
-      const knockingPort: number = 6677;
+      const knockingPort: number = await getPort();
       const knockingUrl: string = `http://localhost:${knockingPort}`;
       const openKnockingSeq: string[] = ["/82", "/delta", "/echo"];
       const closeKnockingSeq: string[] = ["/alpha", "/one", "/one", "/three"];
@@ -928,7 +929,7 @@ describe("knockingServer", ()=>{
 
 
     it("should update knocking sequence automatically", async ()=>{
-      const knockingPort: number = 6677;
+      const knockingPort: number = await getPort();
       const knockingUrl: string = `http://localhost:${knockingPort}`;
       const openKnockingSeq: string[] = ["/82", "/delta", "/echo"];
       const closeKnockingSeq: string[] = ["/alpha", "/one", "/one", "/three"];
@@ -999,7 +1000,7 @@ describe("knockingServer", ()=>{
     });
 
     it("should notify a Webhook server by auto knocking-update", async ()=>{
-      const knockingPort: number = 6677;
+      const knockingPort: number = await getPort();
       const webhookPort: number = 8899;
       const knockingUrl: string = `http://localhost:${knockingPort}`;
       const webhookUrl: string = `http://localhost:${webhookPort}`;

--- a/test/knocking-server.test.ts
+++ b/test/knocking-server.test.ts
@@ -1001,7 +1001,7 @@ describe("knockingServer", ()=>{
 
     it("should notify a Webhook server by auto knocking-update", async ()=>{
       const knockingPort: number = await getPort();
-      const webhookPort: number = 8899;
+      const webhookPort: number = await getPort();
       const knockingUrl: string = `http://localhost:${knockingPort}`;
       const webhookUrl: string = `http://localhost:${webhookPort}`;
       const openKnockingSeq: string[] = ["/82", "/delta", "/echo"];


### PR DESCRIPTION
## Changed
* Use get-port for knockingPort in test
* Unsupport node 6 in CIs because of get-port not supported

**This PR only affects the test program**.


## Not yet

The following part is also a candidate to use `get-port`.

https://github.com/nwtgck/http-knocking/blob/7ae66168549f0d8f18d5eb00fe1d258ee9371302/test/knocking-server.test.ts#L77-L78

However,  A callback of `context()` in mocha cannot be an async function now. We have some options to use `get-port` for `targetServerPort `. 

* option1: Define `targetServerPort` as `let` and assign `0` and Define `targetServer` as `let` and assign `null as any` because or change type definition to `http.Server | undefined` and use `before()`
* option2: Define `targetServerPort` and `targetServer` as Promise and use `await` in each `it()`

But, I don't think the two options are beautiful. 

* The benefit of option1 is fewer changes. But I don't think `let` is good because reassign once in `before()`.
* The benefit of option2 is clean. We can use `const`. But each `it()` have to use `await`.

Because the change is in test code and not an emergency. I decided to keep it.